### PR TITLE
add abstraction for I2C drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,33 @@ be minimised.
 The library has been tested with the
 [Adafruit INA219 Breakout](https://www.adafruit.com/products/904).
 
-## Installation and Upgrade
+## Installation
 
-This library and its dependency
-([Adafruit GPIO library](https://github.com/adafruit/Adafruit_Python_GPIO))
-can be installed from PyPI by executing:
+This library and its dependency can be installed from PyPI by executing:
 
 ```shell
 pip3 install pi-ina219
 ```
 
-To upgrade from a previous version installed direct from Github execute:
+## I2C driver support
 
+This library provides a generic I2C driver interface which allows the usage
+with different I2C driver libraries, such as `smbus`,
+[smbus2](https://github.com/kplindegaard/smbus2) or
+[Adafruit GPIO library](https://github.com/adafruit/Adafruit_Python_GPIO).
+See `example.py` for implementations using mentioned libraries.
+
+Those three I2C driver libraries are supported by the Raspberry Pi models,
+but there may be others. Remember to enable the I2C bus under the
+_Advanced Options_ of _raspi-config_.
+
+The `pi-ina219` library can be installed with support of a specific driver
+libraries:
 ```shell
-pip3 uninstall pi-ina219
-pip3 install pi-ina219
+pip3 install pi-ina219[smbus]
+pip3 install pi-ina219[smbus2]
+pip3 install pi-ina219[Adafruit]
 ```
-
-The Adafruit library supports the I2C protocol on all versions of the
-Raspberry Pi. Remember to enable the I2C bus under the _Advanced Options_
-of _raspi-config_.
 
 ## Usage
 

--- a/example.py
+++ b/example.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 import logging
-from ina219 import INA219
+
+from ina219 import INA219, drivers
+
 
 SHUNT_OHMS = 0.1
 MAX_EXPECTED_AMPS = 0.2
@@ -11,8 +13,19 @@ def read():
 
     i2c_addr = INA219.i2c_addr()
 
+    # old interface (internal I2C driver detection)
     ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, address=i2c_addr,
                  log_level=logging.INFO)
+
+    # new interface passing explicit I2C driver
+    driver = drivers.auto(interface=1)
+    # driver = drivers.SmbusDriver.load(interface=1)
+    # driver = drivers.Smbus2Driver.load(interface=1)
+    # driver = drivers.AdafruitDriver.load(interface=1)
+    ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, address=i2c_addr,
+                 log_level=logging.INFO,
+                 i2c_driver=driver)
+
     ina.configure(ina.RANGE_16V, ina.GAIN_AUTO)
 
     print("Bus Voltage    : %.3f V" % ina.voltage())

--- a/ina219/__init__.py
+++ b/ina219/__init__.py
@@ -1,0 +1,1 @@
+from .ina219 import INA219, I2cDriver, DeviceRangeError  # noqa: F401

--- a/ina219/drivers.py
+++ b/ina219/drivers.py
@@ -1,0 +1,60 @@
+import logging
+import struct
+from typing import Any, cast, List
+
+from .ina219 import I2cDriver
+
+
+class SmbusDriver(I2cDriver):
+
+    def __init__(self, smbus: Any) -> None:
+        self._i2c = smbus
+
+    def write(self, address: int, register: int, data: bytes) -> None:
+        self._i2c.write_i2c_block_data(address, register,
+                                       [int(b) for b in data])
+
+    def read_word(self, address: int, register: int,
+                  signed: bool = False) -> int:
+        data = cast(List[int],
+                    self._i2c.read_i2c_block_data(address, register, 2))
+        return cast(int,
+                    struct.unpack('>h' if signed else '>H', bytes(data))[0])
+
+    @classmethod
+    def load(cls, interface: int) -> I2cDriver:
+        from smbus import SMBus  # type: ignore
+        return cls(SMBus(interface))
+
+
+class Smbus2Driver(SmbusDriver):
+
+    @classmethod
+    def load(cls, interface: int) -> I2cDriver:
+        from smbus2 import SMBus  # type: ignore
+        return cls(SMBus(interface))
+
+
+class AdafruitDriver(SmbusDriver):
+
+    @classmethod
+    def load(cls, interface: int) -> I2cDriver:
+        import Adafruit_PureIO.smbus  # type: ignore
+        return cls(Adafruit_PureIO.smbus.SMBus(interface))
+
+
+def auto(interface: int) -> I2cDriver:
+
+    drivers = [Smbus2Driver, SmbusDriver, AdafruitDriver]
+
+    for driver in drivers:
+        try:
+            loaded = driver.load(interface)
+            logging.info(f'Auto-loading I2C driver: {driver.__name__}')
+            return loaded
+        except ImportError:
+            pass
+
+    raise ModuleNotFoundError('No compatible I2C module found. '
+                              'Supported I2C driver modules are: '
+                              f'{[d.__name__ for d in drivers]}')

--- a/ina219/ina219.py
+++ b/ina219/ina219.py
@@ -2,12 +2,13 @@
 
 Supports the Raspberry Pi using the I2C bus.
 """
+import abc
 from enum import IntEnum
 import logging
-import time
 from math import trunc
-from typing import cast, List, Optional
-import Adafruit_GPIO.I2C as I2C  # type: ignore
+import struct
+import time
+from typing import Optional
 
 
 class INA219:
@@ -34,7 +35,9 @@ class INA219:
     ADC_64SAMP = 14  # 64 samples at 12-bit, conversion time 34.05ms.
     ADC_128SAMP = 15  # 128 samples at 12-bit, conversion time 68.10ms.
 
-    __ADDRESS = 0x40
+    BUSNUM_DEFAULT = 1
+
+    I2C_ADDR_DEFAULT = 0x40
 
     class I2cAddrAx(IntEnum):
         """Configuration values for INA219 pins A0 and A1."""
@@ -108,10 +111,13 @@ class INA219:
     # to guarantee that current overflow can always be detected.
     __CURRENT_LSB_FACTOR = 32800
 
-    def __init__(self, shunt_ohms: float,
+    def __init__(self,
+                 shunt_ohms: float,
                  max_expected_amps: Optional[float] = None,
-                 busnum: Optional[int] = None, address: int = __ADDRESS,
-                 log_level: int = logging.ERROR) -> None:
+                 busnum: Optional[int] = None,
+                 address: int = I2C_ADDR_DEFAULT,
+                 log_level: int = logging.ERROR,
+                 i2c_driver: Optional['I2cDriver'] = None) -> None:
         """Construct the class.
 
         Pass in the resistance of the shunt resistor and the maximum expected
@@ -120,10 +126,11 @@ class INA219:
         Arguments:
         shunt_ohms -- value of shunt resistor in Ohms (mandatory).
         max_expected_amps -- the maximum expected current in Amps (optional).
-        address -- the I2C address of the INA219, defaults
-            to *0x40* (optional).
+        busnum -- deprecated and ignored
+        address -- the I2C address of the INA219 device
         log_level -- set to logging.DEBUG to see detailed calibration
             calculations (optional).
+        i2c_driver -- the I2C driver to be used for I2C communication
         """
         if len(logging.getLogger().handlers) == 0:
             # Initialize the root logger only if it hasn't been done yet by a
@@ -132,7 +139,31 @@ class INA219:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(log_level)
 
-        self._i2c = I2C.get_i2c_device(address=address, busnum=busnum)
+        if not i2c_driver:
+            self.logger.warning(
+                'No `i2c_driver` specified. Automatically detecting I2C '
+                'driver using deprecated `busnum` argument. '
+                'WARNING: Future versions of the library will enforce '
+                'explicit passing of an I2C driver instance.')
+            if busnum is None:
+                busnum = self.BUSNUM_DEFAULT
+                self.logger.warning(
+                    f'No `busnum` provided. Using `busnum={busnum}` '
+                    '(default for Raspberry Pi >=2)')
+            from . import drivers
+            i2c_driver = drivers.auto(interface=busnum)
+        else:
+            if busnum is not None:
+                self.logger.warning(
+                    'The busnum argument is ignored. It is deprecated and '
+                    'will be removed in future library versions. Use the '
+                    '`i2c_driver` interface to specify a bus number.')
+
+        assert isinstance(i2c_driver, I2cDriver), \
+            'I2C driver class must be a subclass of I2cDriver'
+
+        self._i2c = i2c_driver
+        self._address = address
         self._shunt_ohms = shunt_ohms
         self._max_expected_amps = max_expected_amps
         self._min_device_current_lsb = self._calculate_min_current_lsb()
@@ -390,10 +421,10 @@ class INA219:
         return self.__read_register(self.__REG_BUSVOLTAGE)
 
     def _current_register(self) -> int:
-        return self.__read_register(self.__REG_CURRENT, True)
+        return self.__read_register(self.__REG_CURRENT, signed=True)
 
     def _shunt_voltage_register(self) -> int:
-        return self.__read_register(self.__REG_SHUNTVOLTAGE, True)
+        return self.__read_register(self.__REG_SHUNTVOLTAGE, signed=True)
 
     def _power_register(self) -> int:
         return self.__read_register(self.__REG_POWER)
@@ -402,28 +433,18 @@ class INA219:
         if voltage_range > len(self.__BUS_RANGE) - 1:
             raise ValueError(self.__VOLT_ERR_MSG)
 
-    def __write_register(self, register: int, register_value: int) -> None:
-        register_bytes = self.__to_bytes(register_value)
+    def __write_register(self, register: int, value: int) -> None:
         self.logger.debug(
             "write register 0x%02x: 0x%04x 0b%s" %
-            (register, register_value,
-             self.__binary_as_string(register_value)))
-        self._i2c.writeList(register, register_bytes)
+            (register, value, self.__binary_as_string(value)))
+        self._i2c.write(self._address, register, struct.pack('>H', value))
 
-    def __read_register(self, register: int,
-                        negative_value_supported: bool = False) -> int:
-        if negative_value_supported:
-            register_value = self._i2c.readS16BE(register)
-        else:
-            register_value = self._i2c.readU16BE(register)
+    def __read_register(self, register: int, signed: bool = False) -> int:
+        value = self._i2c.read_word(self._address, register, signed)
         self.logger.debug(
             "read register 0x%02x: 0x%04x 0b%s" %
-            (register, register_value,
-             self.__binary_as_string(register_value)))
-        return cast(int, register_value)
-
-    def __to_bytes(self, register_value: int) -> List[int]:
-        return [(register_value >> 8) & 0xFF, register_value & 0xFF]
+            (register, value, self.__binary_as_string(value)))
+        return value
 
     def __binary_as_string(self, register_value: int) -> str:
         return bin(register_value)[2:].zfill(16)
@@ -450,3 +471,45 @@ class DeviceRangeError(Exception):
         super(DeviceRangeError, self).__init__(msg)
         self.gain_volts = gain_volts
         self.device_limit_reached = device_max
+
+
+class I2cDriver(abc.ABC):
+    """Abstract super class of an I2C driver, defining required
+       I2C communication primitives.
+
+    Implementations must ensure that the network byte order ("big endian",
+    MSB first) is followed for read and write operations.
+    """
+
+    @classmethod
+    @abc.abstractclassmethod
+    def load(cls, interface: int) -> 'I2cDriver':
+        """Factory method to load a concrete instance of an I2cDriver.
+
+        Arguments:
+        interface -- system I2C interface identifier
+        """
+
+    @abc.abstractmethod
+    def write(self, address: int, register: int, data: bytes) -> None:
+        """Write data bytes to a register address of the I2C device.
+
+        Arguments:
+        address -- I2C slave address of the device to write to
+        register -- register address at which to write data bytes.
+        data -- data bytes to write
+        """
+
+    @abc.abstractmethod
+    def read_word(self, address: int, register: int,
+                  signed: bool = False) -> int:
+        """Read a (16-bit) word from a register address of the I2C device.
+
+        Arguments:
+        address -- I2C slave address of the device to read from
+        register -- register address from which to read.
+        signed -- whether or not to treat the result as a 2's complement
+                  signed number.
+        Returns:
+        (int) -- A 16 bit integer (MSB first).
+        """

--- a/performance-test.py
+++ b/performance-test.py
@@ -2,7 +2,9 @@
 
 import time
 import logging
-from ina219 import INA219
+
+from ina219 import INA219, drivers
+
 
 SHUNT_OHMS = 0.1
 MAX_EXPECTED_AMPS = 0.2
@@ -10,7 +12,8 @@ MAX_EXPECTED_AMPS = 0.2
 READS = 100
 
 
-ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, log_level=logging.INFO)
+ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, log_level=logging.INFO,
+             i2c_driver=drivers.auto(interface=1))
 
 
 def init():

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,6 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Programming Language :: Python :: 3.9',
                'Topic :: System :: Hardware :: Hardware Drivers']
 
-# Define required packages.
-requires = ['Adafruit_GPIO', 'mock']
-
 
 def read_long_description():
     try:
@@ -36,6 +33,11 @@ setup(name='pi-ina219',
       url='https://github.com/chrisb2/pi_ina219/',
       classifiers=classifiers,
       keywords='ina219 raspberrypi',
-      install_requires=requires,
+      extras_require={
+          'smbus': ['smbus'],
+          'smbus2': ['smbus2'],
+          'Adafruit': ['Adafruit-PureIO'],
+      },
+      packages=['ina219'],
       test_suite='tests',
-      py_modules=['ina219'])
+      )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,8 +1,11 @@
 import sys
 import logging
 import unittest
-from mock import Mock, call, patch
-from ina219 import INA219
+
+from mock import Mock, call
+
+from ina219 import INA219, I2cDriver
+
 
 logger = logging.getLogger()
 logger.level = logging.ERROR
@@ -11,162 +14,173 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 
 class TestConfiguration(unittest.TestCase):
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def setUp(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.4)
-        self.ina._i2c.writeList = Mock()
+    def setUp(self):
+        I2cDriver.register(Mock)  # make "Mock" a subclass of "I2cDriver"
+        self.i2c = Mock()
+        self.ina = INA219(0.1, 0.4, i2c_driver=self.i2c)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_calibration_register_maximum_is_fffe_1_ohm(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(1.0, 0.01)
+    def test_calibration_register_maximum_is_fffe_1_ohm(self):
+        self.ina = INA219(1.0, 0.01, i2c_driver=self.i2c)
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
-        calls = [call(0x05, [0xFF, 0xFE]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0xFF, 0xFE])),
+                 call(0x40, 0x00, bytes([0x01, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_calibration_register_maximum_is_fffe_100_mohm(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.1)
+    def test_calibration_register_maximum_is_fffe_100_mohm(self):
+        self.ina = INA219(0.1, 0.1, i2c_driver=self.i2c)
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
-        calls = [call(0x05, [0xFF, 0xFE]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0xFF, 0xFE])),
+                 call(0x40, 0x00, bytes([0x01, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_calibration_register_maximum_is_fffe_10_mohm(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.01, 0.1)
+    def test_calibration_register_maximum_is_fffe_10_mohm(self):
+        self.ina = INA219(0.01, 0.1, i2c_driver=self.i2c)
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
-        calls = [call(0x05, [0xFF, 0xFE]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0xFF, 0xFE])),
+                 call(0x40, 0x00, bytes([0x01, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_auto_gain_with_expected_amps(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
         self.assertEqual(self.ina._gain, 1)
         self.assertEqual(self.ina._voltage_range, 0)
         self.assertTrue(self.ina._auto_gain_enabled)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x09, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x09, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_auto_gain_no_expected_amps(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1)
+    def test_auto_gain_no_expected_amps(self):
+        self.ina = INA219(0.1, i2c_driver=self.i2c)
         self.ina._i2c.writeList = Mock()
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
         self.assertEqual(self.ina._gain, self.ina.GAIN_1_40MV)
         self.assertTrue(self.ina._auto_gain_enabled)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x01, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_manual_gain_no_expected_amps(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1)
+    def test_manual_gain_no_expected_amps(self):
+        self.ina = INA219(0.1, i2c_driver=self.i2c)
         self.ina._i2c.writeList = Mock()
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.assertEqual(self.ina._gain, self.ina.GAIN_1_40MV)
         self.assertFalse(self.ina._auto_gain_enabled)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x01, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_auto_gain_out_of_range(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 4)
+    def test_auto_gain_out_of_range(self):
+        self.ina = INA219(0.1, 4, i2c_driver=self.i2c)
         with self.assertRaisesRegex(ValueError, "Expected amps"):
             self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
 
     def test_16v_40mv(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.assertEqual(self.ina._gain, 0)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x01, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_40mv(self):
         self.ina.configure(self.ina.RANGE_32V, self.ina.GAIN_1_40MV)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x21, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x21, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_80mv(self):
         self.ina.configure(self.ina.RANGE_32V, self.ina.GAIN_2_80MV)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x29, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x29, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_160mv(self):
         self.ina.configure(self.ina.RANGE_32V, self.ina.GAIN_4_160MV)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x31, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x31, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_320mv(self):
         self.ina.configure(self.ina.RANGE_32V, self.ina.GAIN_8_320MV)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x39, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x39, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_40mv_9bit(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_9BIT, self.ina.ADC_9BIT)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x20, 0x07])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x20, 0x07]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_40mv_10_bit_11_bit(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_10BIT, self.ina.ADC_11BIT)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x20, 0x97])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x20, 0x97]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_40mv_2_samples_128_samples(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_2SAMP, self.ina.ADC_128SAMP)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x24, 0xff])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x24, 0xff]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_40mv_4_samples_8_samples(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_4SAMP, self.ina.ADC_8SAMP)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x25, 0x5f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x25, 0x5f]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_40mv_8_samples_16_samples(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_8SAMP, self.ina.ADC_16SAMP)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x25, 0xe7])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x25, 0xe7]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_32v_40mv_32_samples_64_samples(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_32SAMP, self.ina.ADC_64SAMP)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x26, 0xf7])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x26, 0xf7]))]
+        self.i2c.write.assert_has_calls(calls)
 
     def test_invalid_voltage_range(self):
         with self.assertRaisesRegex(ValueError, "Invalid voltage range"):
             self.ina.configure(64, self.ina.GAIN_1_40MV)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_max_current_exceeded(self, device):
-        device.return_value = Mock()
-        ina = INA219(0.1, 0.5)
+    def test_max_current_exceeded(self):
+        ina = INA219(0.1, 0.5, i2c_driver=self.i2c)
         with self.assertRaisesRegex(ValueError, "Expected current"):
-            ina.configure(ina.RANGE_32V, ina.GAIN_1_40MV)
+            ina.configure(self.ina.RANGE_32V, ina.GAIN_1_40MV)
 
     def test_sleep(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0xf)
+        self.i2c.read_word = Mock(return_value=0x0F)
         self.ina.sleep()
-        self.ina._i2c.writeList.assert_called_with(0x00, [0x00, 0x08])
+        self.i2c.write.assert_called_with(
+            0x40, 0x00, bytes([0x00, 0x08]))
 
     def test_wake(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0x8)
+        self.i2c.read_word = Mock(return_value=0x08)
         self.ina.wake()
-        self.ina._i2c.writeList.assert_called_with(0x00, [0x00, 0xf])
+        self.i2c.write.assert_called_with(
+            0x40, 0x00, bytes([0x00, 0xf]))
 
     def test_reset(self):
         self.ina.reset()
-        self.ina._i2c.writeList.assert_called_with(0x00, [0x80, 0x00])
+        self.i2c.write.assert_called_with(
+            0x40, 0x00, bytes([0x80, 0x00]))
+
+    def test_i2c_addr(self):
+        ina = INA219(0.1, 0.5, address=0x41, i2c_driver=self.i2c)
+        ina.reset()
+        self.i2c.write.assert_called_with(
+            0x41, 0x00, bytes([0x80, 0x00]))

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -1,8 +1,11 @@
 import sys
 import logging
 import unittest
+
 from mock import Mock, patch
-from ina219 import INA219
+
+from ina219 import INA219, I2cDriver
+
 
 logger = logging.getLogger()
 logger.level = logging.ERROR
@@ -11,19 +14,41 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 
 class TestConstructor(unittest.TestCase):
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_default(self, device):
-        device.return_value = Mock()
+    def setUp(self):
+        I2cDriver.register(Mock)  # make "Mock" a subclass of "I2cDriver"
+        self.i2c = Mock()
+
+    @patch('ina219.drivers')
+    def test_old_interface(self, drivers):
+        drivers.auto = Mock()
+
         self.ina = INA219(0.1)
+        drivers.auto.assert_called_with(interface=1)
+
+        # with busnum
+        self.ina = INA219(0.1, busnum=2)
+        drivers.auto.assert_called_with(interface=2)
+
+    @patch('logging.getLogger')
+    def test_new_interface_with_deprecated_busnum(self, logger):
+        self.ina = INA219(0.1, busnum=0, i2c_driver=self.i2c)
+        self.ina.logger.warning.assert_called()
+
+    def test_default(self):
+        self.ina = INA219(0.1, i2c_driver=self.i2c)
         self.assertEqual(self.ina._shunt_ohms, 0.1)
         self.assertIsNone(self.ina._max_expected_amps)
         self.assertIsNone(self.ina._gain)
         self.assertFalse(self.ina._auto_gain_enabled)
         self.assertAlmostEqual(self.ina._min_device_current_lsb, 6.25e-6, 2)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_with_max_expected_amps(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.4)
+    def test_with_max_expected_amps(self):
+        self.ina = INA219(0.1, 0.4, i2c_driver=self.i2c)
         self.assertEqual(self.ina._shunt_ohms, 0.1)
         self.assertEqual(self.ina._max_expected_amps, 0.4)
+
+    def test_with_invalid_i2c_device_class(self):
+        non_i2c_driver_instance = object()
+        exp_exc_msg = 'I2C driver class must be a subclass of I2cDriver'
+        with self.assertRaisesRegex(AssertionError, exp_exc_msg):
+            self.ina = INA219(0x40, 0, i2c_driver=non_i2c_driver_instance)

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,0 +1,111 @@
+import sys
+import logging
+import unittest
+
+from mock import Mock, patch
+
+from ina219 import drivers
+
+
+logger = logging.getLogger()
+logger.level = logging.ERROR
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+class TestDrivers(unittest.TestCase):
+
+    def setUp(self) -> None:
+        sys.modules['smbus'] = Mock()
+        sys.modules['smbus2'] = Mock()
+        sys.modules['Adafruit_PureIO'] = Mock()
+        sys.modules['Adafruit_PureIO.smbus'] = Mock()
+
+    def tearDown(self) -> None:
+        if 'smbus' in sys.modules:
+            del sys.modules['smbus']
+        if 'smbus2' in sys.modules:
+            del sys.modules['smbus2']
+        if 'Adafruit_PureIO' in sys.modules:
+            del sys.modules['Adafruit_PureIO']
+        if 'Adafruit_PureIO.smbus' in sys.modules:
+            del sys.modules['Adafruit_PureIO.smbus']
+
+    @patch('smbus.SMBus')
+    def test_smbus_driver(self, smbus):
+
+        driver = drivers.SmbusDriver.load(interface=123)
+        driver.write(0xAB, 0xCD, b'\xaa\xbb\xcc\xdd')
+
+        smbus.assert_called_with(123)
+
+        instance = smbus.return_value
+
+        instance.write_i2c_block_data.assert_called_with(
+            0xAB, 0xCD, [0xaa, 0xbb, 0xcc, 0xdd])
+
+        instance.read_i2c_block_data.return_value = [0xAB, 0xCD]
+        read_unsigned = driver.read_word(0xBA, 0xDC, signed=False)
+        self.assertEqual(read_unsigned, 0xABCD)
+
+        instance.read_i2c_block_data.return_value = [0xAB, 0xCD]
+        read_signed = driver.read_word(0xBA, 0xDC, signed=True)
+        self.assertEqual(read_signed, -21555)
+
+    @patch('smbus2.SMBus')
+    def test_smbus2_driver(self, smbus):
+
+        driver = drivers.Smbus2Driver.load(interface=123)
+        driver.write(0xAB, 0xCD, b'\xaa\xbb\xcc\xdd')
+
+        smbus.assert_called_with(123)
+
+        instance = smbus.return_value
+
+        instance.write_i2c_block_data.assert_called_with(
+            0xAB, 0xCD, [0xaa, 0xbb, 0xcc, 0xdd])
+
+        instance.read_i2c_block_data.return_value = [0xAB, 0xCD]
+        read_unsigned = driver.read_word(0xBA, 0xDC, signed=False)
+        self.assertEqual(read_unsigned, 0xABCD)
+
+        instance.read_i2c_block_data.return_value = [0xAB, 0xCD]
+        read_signed = driver.read_word(0xBA, 0xDC, signed=True)
+        self.assertEqual(read_signed, -21555)
+
+    @patch('Adafruit_PureIO.smbus.SMBus')
+    def test_adafruit_driver(self, smbus):
+
+        driver = drivers.AdafruitDriver.load(interface=123)
+        driver.write(0xAB, 0xCD, b'\xaa\xbb\xcc\xdd')
+
+        smbus.assert_called_with(123)
+
+        instance = smbus.return_value
+
+        instance.write_i2c_block_data.assert_called_with(
+            0xAB, 0xCD, [0xaa, 0xbb, 0xcc, 0xdd])
+
+        instance.read_i2c_block_data.return_value = [0xAB, 0xCD]
+        read_unsigned = driver.read_word(0xBA, 0xDC, signed=False)
+        self.assertEqual(read_unsigned, 0xABCD)
+
+        instance.read_i2c_block_data.return_value = [0xAB, 0xCD]
+        read_signed = driver.read_word(0xBA, 0xDC, signed=True)
+        self.assertEqual(read_signed, -21555)
+
+    def test_auto_driver(self):
+        driver = drivers.auto(interface=321)
+        self.assertEqual(driver.__class__, drivers.Smbus2Driver)
+
+        del sys.modules['smbus2']
+        driver = drivers.auto(interface=321)
+        self.assertEqual(driver.__class__, drivers.SmbusDriver)
+
+        del sys.modules['smbus']
+        driver = drivers.auto(interface=321)
+        self.assertEqual(driver.__class__, drivers.AdafruitDriver)
+
+        del sys.modules['Adafruit_PureIO.smbus']
+        exp_exc_msg = 'No compatible I2C module found'
+        with self.assertRaisesRegex(ModuleNotFoundError, exp_exc_msg):
+            driver = drivers.auto(interface=321)

--- a/tests/test_i2c_addr.py
+++ b/tests/test_i2c_addr.py
@@ -1,7 +1,9 @@
 import sys
 import logging
 import unittest
+
 from ina219 import INA219
+
 
 logger = logging.getLogger()
 logger.level = logging.ERROR

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,9 +1,10 @@
 import sys
 import logging
 import unittest
-from mock import Mock, patch
-from ina219 import INA219
-from ina219 import DeviceRangeError
+
+from mock import Mock
+
+from ina219 import INA219, I2cDriver, DeviceRangeError
 
 
 logger = logging.getLogger()
@@ -15,26 +16,25 @@ class TestRead(unittest.TestCase):
 
     GAIN_RANGE_MSG = r"Current out of range \(overflow\)"
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def setUp(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.4)
-        self.ina._i2c.writeList = Mock()
+    def setUp(self):
+        I2cDriver.register(Mock)  # make "Mock" a subclass of "I2cDriver"
+        self.i2c = Mock()
+        self.ina = INA219(0.1, 0.4, i2c_driver=self.i2c)
 
     def test_read_32v(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0xfa00)
+        self.i2c.read_word = Mock(return_value=0xfa00)
         self.assertEqual(self.ina.voltage(), 32)
 
     def test_read_16v(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0x7d00)
+        self.i2c.read_word = Mock(return_value=0x7d00)
         self.assertEqual(self.ina.voltage(), 16)
 
     def test_read_4_808v(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0x2592)
+        self.i2c.read_word = Mock(return_value=0x2592)
         self.assertEqual(self.ina.voltage(), 4.808)
 
     def test_read_4mv(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0x8)
+        self.i2c.read_word = Mock(return_value=0x8)
         self.assertEqual(self.ina.voltage(), 0.004)
 
     def test_read_supply_voltage(self):
@@ -43,73 +43,73 @@ class TestRead(unittest.TestCase):
         self.assertEqual(self.ina.supply_voltage(), 2.539)
 
     def test_read_0v(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0)
+        self.i2c.read_word = Mock(return_value=0)
         self.assertEqual(self.ina.voltage(), 0)
 
     def test_read_12ua(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=0x1)
+        self.i2c.read_word = Mock(return_value=0x1)
         self.assertAlmostEqual(self.ina.current(), 0.012, 3)
 
     def test_read_0ma(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=0)
+        self.i2c.read_word = Mock(return_value=0)
         self.assertEqual(self.ina.current(), 0)
 
     def test_read_negative_ma(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=-0x4d52)
+        self.i2c.read_word = Mock(return_value=-0x4d52)
         self.assertAlmostEqual(self.ina.current(), -241.4, 1)
 
     def test_read_0mw(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0)
+        self.i2c.read_word = Mock(return_value=0)
         self.assertEqual(self.ina.power(), 0)
 
     def test_read_1914mw(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readU16BE = Mock(return_value=0x1ea9)
+        self.i2c.read_word = Mock(return_value=0x1ea9)
         self.assertAlmostEqual(self.ina.power(), 1914.0, 0)
 
     def test_read_shunt_20mv(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=0x7d0)
+        self.i2c.read_word = Mock(return_value=0x7d0)
         self.assertEqual(self.ina.shunt_voltage(), 20.0)
 
     def test_read_shunt_0mv(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=0)
+        self.i2c.read_word = Mock(return_value=0)
         self.assertEqual(self.ina.shunt_voltage(), 0)
 
     def test_read_shunt_negative_40mv(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=-0xfa0)
+        self.i2c.read_word = Mock(return_value=-0xfa0)
         self.assertEqual(self.ina.shunt_voltage(), -40.0)
 
     def test_current_overflow_valid(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0xfa1)
+        self.i2c.read_word = Mock(return_value=0xfa1)
         self.assertTrue(self.ina.current_overflow())
 
     def test_current_overflow_error(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0xfa1)
+        self.i2c.read_word = Mock(return_value=0xfa1)
         with self.assertRaisesRegex(DeviceRangeError, self.GAIN_RANGE_MSG):
             self.ina.current()
 
     def test_new_read_available(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0xA)
+        self.i2c.read_word = Mock(return_value=0xA)
         self.assertTrue(self.ina.is_conversion_ready())
 
     def test_new_read_not_available(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0x8)
+        self.i2c.read_word = Mock(return_value=0x8)
         self.assertFalse(self.ina.is_conversion_ready())

--- a/tests/test_read_auto_gain.py
+++ b/tests/test_read_auto_gain.py
@@ -1,9 +1,10 @@
 import sys
 import logging
 import unittest
-from mock import Mock, call, patch
-from ina219 import INA219
-from ina219 import DeviceRangeError
+
+from mock import Mock, call
+
+from ina219 import INA219, I2cDriver, DeviceRangeError
 
 logger = logging.getLogger()
 logger.level = logging.ERROR
@@ -14,11 +15,12 @@ class TestReadAutoGain(unittest.TestCase):
 
     GAIN_RANGE_MSG = r"Current out of range \(overflow\)"
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_auto_gain(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.4)
-        self.ina._i2c.writeList = Mock()
+    def setUp(self):
+        I2cDriver.register(Mock)  # make "Mock" a subclass of "I2cDriver"
+        self.i2c = Mock()
+
+    def test_auto_gain(self):
+        self.ina = INA219(0.1, 0.4, i2c_driver=self.i2c)
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
 
         self.ina._read_voltage_register = Mock()
@@ -29,15 +31,14 @@ class TestReadAutoGain(unittest.TestCase):
 
         self.assertAlmostEqual(self.ina.current(), 4.878, 3)
 
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x09, 0x9f]),
-                 call(0x05, [0x20, 0xcc]), call(0x00, [0x11, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x40, 0x05, bytes([0x83, 0x33])),
+                 call(0x40, 0x00, bytes([0x09, 0x9f])),
+                 call(0x40, 0x05, bytes([0x20, 0xcc])),
+                 call(0x40, 0x00, bytes([0x11, 0x9f]))]
+        self.i2c.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_auto_gain_out_of_range(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 3.0)
-        self.ina._i2c.writeList = Mock()
+    def test_auto_gain_out_of_range(self):
+        self.ina = INA219(3.0, i2c_driver=self.i2c)
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
 
         self.ina._read_voltage_register = Mock(return_value=0xfa1)


### PR DESCRIPTION
Adding a driver abstraction to make the library independent from the actually used I2C library.

In order to provide basic Raspberry Pi driver functionality within the package (smbus, smbus2, Adafruit-PureIO), I slightly refactored the package structure to also deliver the `drivers.py` module.

The API of `INA219` remains the same, but the `busnum` argument is obsolete when using the new `i2c_driver` argument. It is hence marked as deprecated for future versions.