### PR TITLE
refactor logging out of ina219 driver

### DIFF
--- a/example.py
+++ b/example.py
@@ -9,13 +9,17 @@ SHUNT_OHMS = 0.1
 MAX_EXPECTED_AMPS = 0.2
 
 
+LOG_LEVEL = logging.WARN
+LOG_FORMAT = '%(asctime)s - %(levelname)s - INA219 %(message)s'
+logging.basicConfig(level=LOG_LEVEL, format=LOG_FORMAT)
+
+
 def read():
 
     i2c_addr = INA219.i2c_addr()
 
     # old interface (internal I2C driver detection)
-    ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, address=i2c_addr,
-                 log_level=logging.INFO)
+    # ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, address=i2c_addr)
 
     # new interface passing explicit I2C driver
     driver = drivers.auto(interface=1)
@@ -23,7 +27,6 @@ def read():
     # driver = drivers.Smbus2Driver.load(interface=1)
     # driver = drivers.AdafruitDriver.load(interface=1)
     ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, address=i2c_addr,
-                 log_level=logging.INFO,
                  i2c_driver=driver)
 
     ina.configure(ina.RANGE_16V, ina.GAIN_AUTO)

--- a/ina219/ina219.py
+++ b/ina219/ina219.py
@@ -93,7 +93,6 @@ class INA219:
     __VOLT_ERR_MSG = ('Invalid voltage range, must be one of: '
                       'RANGE_16V, RANGE_32V')
 
-    __LOG_FORMAT = '%(asctime)s - %(levelname)s - INA219 %(message)s'
     __LOG_MSG_1 = ('shunt ohms: %.3f, bus max volts: %d, '
                    'shunt volts max: %.2f%s, '
                    'bus ADC: %d, shunt ADC: %d')
@@ -116,7 +115,7 @@ class INA219:
                  max_expected_amps: Optional[float] = None,
                  busnum: Optional[int] = None,
                  address: int = I2C_ADDR_DEFAULT,
-                 log_level: int = logging.ERROR,
+                 log_level: Optional[int] = None,
                  i2c_driver: Optional['I2cDriver'] = None) -> None:
         """Construct the class.
 
@@ -128,16 +127,17 @@ class INA219:
         max_expected_amps -- the maximum expected current in Amps (optional).
         busnum -- deprecated and ignored
         address -- the I2C address of the INA219 device
-        log_level -- set to logging.DEBUG to see detailed calibration
-            calculations (optional).
+        log_level -- deprecated and ignored
         i2c_driver -- the I2C driver to be used for I2C communication
         """
-        if len(logging.getLogger().handlers) == 0:
-            # Initialize the root logger only if it hasn't been done yet by a
-            # parent module.
-            logging.basicConfig(level=log_level, format=self.__LOG_FORMAT)
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(log_level)
+
+        if log_level is not None:
+            self.logger.warning(
+                 'The `log_level` argument is deprecated and will be '
+                 'removed in future library versions. The argument is '
+                 'ignored. Loglevel needs to be set externally for '
+                 'this module.')
 
         if not i2c_driver:
             self.logger.warning(

--- a/performance-test.py
+++ b/performance-test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import time
-import logging
 
 from ina219 import INA219, drivers
 
@@ -12,7 +11,7 @@ MAX_EXPECTED_AMPS = 0.2
 READS = 100
 
 
-ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, log_level=logging.INFO,
+ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS,
              i2c_driver=drivers.auto(interface=1))
 
 

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -34,6 +34,11 @@ class TestConstructor(unittest.TestCase):
         self.ina = INA219(0.1, busnum=0, i2c_driver=self.i2c)
         self.ina.logger.warning.assert_called()
 
+    @patch('logging.getLogger')
+    def test_deprecated_loglevel_argument(self, logger):
+        self.ina = INA219(0.1, log_level=1, i2c_driver=self.i2c)
+        self.ina.logger.warning.assert_called()
+
     def test_default(self):
         self.ina = INA219(0.1, i2c_driver=self.i2c)
         self.assertEqual(self.ina._shunt_ohms, 0.1)


### PR DESCRIPTION
Logging should be configured by parent modules. Although the code supported this, there should be no need to have an internal configuration of logging.

Removing this dependency makes logging cleaner.

The API of INA219 is kept compatible to older versions, but the `log_level` arg is now ignored and marked as deprecated.