### PR TITLE
unittest: fix deprecation warnings and cleanup testing dependencies

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 codecov
+        python -m pip install flake8
         pip install -r tests/requirements.txt
     - name: Lint with flake8
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .coverage
+coverage.xml
 build
 dist
 pi_ina219.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
 # command to install dependencies
 install:
   - pip install flake8
-  - pip install codecov
   - pip install -r tests/requirements.txt
 # check PEP8 coding standard with flake8
 before_script:

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ This library and its dependency
 can be installed from PyPI by executing:
 
 ```shell
-sudo pip3 install pi-ina219
+pip3 install pi-ina219
 ```
 
 To upgrade from a previous version installed direct from Github execute:
 
 ```shell
-sudo pip3 uninstall pi-ina219
-sudo pip3 install pi-ina219
+pip3 uninstall pi-ina219
+pip3 install pi-ina219
 ```
 
 The Adafruit library supports the I2C protocol on all versions of the
@@ -293,10 +293,10 @@ Detailed logging of device register operations can be enabled with:
 
 ## Testing
 
-Install the library as described above, this will install all the
-dependencies required for the unit tests, as well as the library
-itself. Clone the library source from Github then execute the test suite
-from the top level directory with:
+Install test dependencies first _(recommended to use virtual environments)_:
+```shell
+pip3 install -r tests/requirements.txt
+```
 
 ```shell
 python3 -m unittest discover -s tests -p 'test_*.py'
@@ -313,6 +313,7 @@ Code coverage metrics may be generated and viewed with:
 ```shell
 coverage run --branch --source=ina219 -m unittest discover -s tests -p 'test_*.py'
 coverage report -m
+coverage xml
 ```
 
 ## Coding Standard

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,4 @@
 Adafruit_GPIO==1.0.1
 mock==2.0.0
+coverage==5.1
+codecov>=2.1

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -75,7 +75,7 @@ class TestConfiguration(unittest.TestCase):
     def test_auto_gain_out_of_range(self, device):
         device.return_value = Mock()
         self.ina = INA219(0.1, 4)
-        with self.assertRaisesRegexp(ValueError, "Expected amps"):
+        with self.assertRaisesRegex(ValueError, "Expected amps"):
             self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
 
     def test_16v_40mv(self):
@@ -147,14 +147,14 @@ class TestConfiguration(unittest.TestCase):
         self.ina._i2c.writeList.assert_has_calls(calls)
 
     def test_invalid_voltage_range(self):
-        with self.assertRaisesRegexp(ValueError, "Invalid voltage range"):
+        with self.assertRaisesRegex(ValueError, "Invalid voltage range"):
             self.ina.configure(64, self.ina.GAIN_1_40MV)
 
     @patch('Adafruit_GPIO.I2C.get_i2c_device')
     def test_max_current_exceeded(self, device):
         device.return_value = Mock()
         ina = INA219(0.1, 0.5)
-        with self.assertRaisesRegexp(ValueError, "Expected current"):
+        with self.assertRaisesRegex(ValueError, "Expected current"):
             ina.configure(ina.RANGE_32V, ina.GAIN_1_40MV)
 
     def test_sleep(self):

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -101,7 +101,7 @@ class TestRead(unittest.TestCase):
     def test_current_overflow_error(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
         self.ina._i2c.readU16BE = Mock(return_value=0xfa1)
-        with self.assertRaisesRegexp(DeviceRangeError, self.GAIN_RANGE_MSG):
+        with self.assertRaisesRegex(DeviceRangeError, self.GAIN_RANGE_MSG):
             self.ina.current()
 
     def test_new_read_available(self):

--- a/tests/test_read_auto_gain.py
+++ b/tests/test_read_auto_gain.py
@@ -43,5 +43,5 @@ class TestReadAutoGain(unittest.TestCase):
         self.ina._read_voltage_register = Mock(return_value=0xfa1)
         self.ina._read_configuration = Mock(return_value=0x199f)
 
-        with self.assertRaisesRegexp(DeviceRangeError, self.GAIN_RANGE_MSG):
+        with self.assertRaisesRegex(DeviceRangeError, self.GAIN_RANGE_MSG):
             self.ina.current()


### PR DESCRIPTION
- Cleaning up deprecation warnings (using `unittest 3.8`)
- moving tests dependencies into `tests/requirements.txt`, to help local execution
- update `README.md`:
  - discourage to use `sudo` when installing `pip` packages
  - discourage to install the <self> package for testing - that is not necessary
  - encourage to install requirements from `tests/requirements.txt`